### PR TITLE
Remove unneeded patch from Python-3.5.2 formula.

### DIFF
--- a/Formula/python3.rb
+++ b/Formula/python3.rb
@@ -7,14 +7,6 @@ class Python3 < Formula
   stable do
     url "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz"
     sha256 "0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40"
-
-    # Fix extension module builds against Xcode 7 SDKs
-    # https://github.com/Homebrew/homebrew/issues/41085
-    # https://bugs.python.org/issue25136
-    patch do
-      url "https://bugs.python.org/file40478/xcode-stubs.diff"
-      sha256 "029cc0dc72b1bcf4ddc5f913cc4a3fd970378073c6355921891f041aca2f8b12"
-    end
   end
 
   bottle do

--- a/Formula/python3.rb
+++ b/Formula/python3.rb
@@ -41,13 +41,13 @@ class Python3 < Formula
   skip_clean "bin/easy_install3", "bin/easy_install-3.4", "bin/easy_install-3.5"
 
   resource "setuptools" do
-    url "https://pypi.python.org/packages/source/s/setuptools/setuptools-23.1.tar.gz"
-    sha256 "53c7ec9ff6396ee6a4549b49f7d6c65e4966eefe932596e09d7d59229d47356c"
+    url "https://pypi.python.org/packages/9f/7c/0a33c528164f1b7ff8cf0684cf88c2e733c8ae0119ceca4a3955c7fc059d/setuptools-23.1.0.tar.gz"
+    sha256 "4e269d36ba2313e6236f384b36eb97b3433cf99a16b94c74cca7eee2b311f2be"
   end
 
   resource "pip" do
-    url "https://pypi.python.org/packages/source/p/pip/pip-8.1.2.tar.gz"
-    sha256 "a35ff14de848feba9720bd4756892d41158b73db02f33d427ab22137c582fe0b"
+    url "https://pypi.python.org/packages/e7/a8/7556133689add8d1a54c0b14aeff0acb03c64707ce100ecd53934da1aa13/pip-8.1.2.tar.gz"
+    sha256 "4d24b03ffa67638a3fa931c09fd9e0273ffa904e95ebebe7d4b1a54c93d7b732"
   end
 
   resource "wheel" do


### PR DESCRIPTION
The patch that is failing to apply is no longer required. It was [applied upstream] (https://github.com/python/cpython/commit/6e0963c9c7849a0cbce2b715c96fbebca687e030) (the only difference between the [patch in this formula](https://bugs.python.org/file40478/xcode-stubs.diff) and the upstream commit is that the upstream commit also added some comments explaining it).

The formula seems to build fine for me by removing that patch.